### PR TITLE
Update cache to use Weakmap instead of Map

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,8 @@ export default (initialState = null) => {
     return class EnhancedComponent extends Component {
       cachedUpdateCount = 0;
       cachedHandleCount = 0;
-      handleCallbacksRefs = new Map();
-      updateCallbacksRefs = new Map();
+      handleCallbacksRefs = new WeakMap();
+      updateCallbacksRefs = new WeakMap();
 
       constructor(props) {
         super(props);


### PR DESCRIPTION
This updates the cache objects to use `Weakmap` instead of `Map` in order to prevent potential memory leaks. `Map`s treat the objects used for keys as a new reference, if the original reference was deleted there would be the reference in the key which would not be garbage collected. Using a `Weakmap` this reference would be garbage collected when the original reference is removed.