### PR TITLE
Update internal implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ export default withUpdater(0)(Component);
 
 Since this wraps the callback handler in a `setState` call, the handler should always return a new state which can be an object or a single value.
 
-**Important:** `update` memoizes up to **30** handlers and returns the same reference. This avoids a common pitfall associated with components that rely on props equality by using `shouldComponentUpdate` which can lead to de-optimizations because `shouldComponentUpdate` will return `true` every time since `props.onClick !== nexProps.onClick`. This way `withUpdater` must ensure it always returns the same reference for each handler.
+**Important:** `update` memoizes the given handlers and returns the same reference. This avoids a common pitfall associated with components that rely on props equality by using `shouldComponentUpdate` which can lead to de-optimizations because `shouldComponentUpdate` will return `true` every time since `props.onClick !== nexProps.onClick`. This way `withUpdater` must ensure it always returns the same reference for each handler.
 
 ```js
 // Bad.
-// This will log a error message after 30 calls.
+// This will log a warning message since the given handler is a anonymous function.
 const Component = props => <div onClick={props.update(state => state + 1)} />;
 
 // Good.
@@ -88,7 +88,7 @@ export default withUpdater()(Component);
 ```
 
 #### `state`
-The main difference here is that you can pass any value to the initial state and it will be handled accordingly. If you pass an object as the initial state, the updater will handle it according to the default `setState()` behavior. If you pass a function to the initial state it will be provided with the owner props that can be used to define the initial state.
+You can pass any value to the initial state and it will be handled accordingly. If you pass an object as the initial state, the updater will handle it according to the default `setState()` behavior. If you pass a function to the initial state it will be provided with the owner props that can be used to define the initial state.
 
 **Arbitrary value**
 

--- a/__tests__/__snapshots__/react-updater.test.js.snap
+++ b/__tests__/__snapshots__/react-updater.test.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`withUpdater handle calls console.error if the maximum number of callbacks is exceeded 1`] = `"Maximum \\"handle\\" callbacks size exceeded. This probably is because you are creating inline handlers inside the render method, which results in a new handler on every render which can lead to de-optimizations by components that rely on props equality."`;
+exports[`Anonymous function warning 1`] = `"Callbacks handlers defined with anonymous functions should be avoided. This can lead to de-optimisations on components that rely on props equality."`;
 
-exports[`withUpdater update calls console.error if the maximum number of callbacks is exceeded 1`] = `"Maximum \\"update\\" callbacks size exceeded. This probably is because you are creating inline handlers inside the render method, which results in a new handler on every render which can lead to de-optimizations by components that rely on props equality."`;
+exports[`memoizedCallbackHandlers collection 1`] = `
+Object {
+  "update[Function handler][]": Object {
+    "callback": [Function],
+    "handler": [Function],
+  },
+}
+`;

--- a/__tests__/__snapshots__/utils.test.js.snap
+++ b/__tests__/__snapshots__/utils.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`utils stringify stringifies an object containing a function 1`] = `"{\\"foo\\":\\"[Function foo]\\",\\"bar\\":\\"[Function bar]\\",\\"biz\\":\\"foo\\"}"`;

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,0 +1,25 @@
+/**
+ * Module dependencies.
+ */
+
+import { noop, stringify } from '../src/utils';
+
+describe('utils', () => {
+  describe('stringify', () => {
+    it('stringifies an object containing a function', () => {
+      const bar = () => {};
+
+      expect(stringify({ foo: () => {}, bar, biz: 'foo' })).toMatchSnapshot();
+    });
+  });
+
+  describe('noop', () => {
+    it('is a function', () => {
+      expect(typeof noop === 'function').toBe(true);
+    });
+
+    it('returns undefined', () => {
+      expect(noop()).toBeUndefined();
+    });
+  });
+});

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,10 @@
+export const stringifyFunction = fn => `[Function ${fn.name}]`;
+export const noop = () => {};
+export const stringify = value =>
+  JSON.stringify(value, (key, value) => {
+    if (typeof value === 'function') {
+      return stringifyFunction(value);
+    }
+
+    return value;
+  });


### PR DESCRIPTION
This is a total refactor of the internals without any changes to the API. This fixes a major issue related with the additional parameters, and cleans up the code so now it is easier to maintain, since now we don't need to keep track of two different collections to cache the callback handlers.
This removes the maximum callback limit, and now it only warns if the given callback handler is a anonymous function.