### PR TITLE
Add support to access event on setState()

### DIFF
--- a/__tests__/react-updater.test.js
+++ b/__tests__/react-updater.test.js
@@ -197,16 +197,46 @@ describe('withUpdater', () => {
       wrapper.find('button').simulate('click');
     });
 
+    it('calls event persist() method', () => {
+      const persist = jest.fn();
+      const handler = (state, event) => event.target.value;
+      const WrappedComponent = props =>
+        <div>
+          <input onChange={props.update(handler)} />
+        </div>;
+      const WithUpdater = withUpdater('')(WrappedComponent);
+      const wrapper = mount(<WithUpdater />);
+
+      wrapper.find('input').simulate('change', { persist });
+
+      expect(persist).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls event destructor() method', () => {
+      const destructor = jest.fn();
+      const handler = (state, event) => event.target.value;
+      const WrappedComponent = props =>
+        <div>
+          <input onChange={props.update(handler)} />
+        </div>;
+      const WithUpdater = withUpdater('')(WrappedComponent);
+      const wrapper = mount(<WithUpdater />);
+
+      wrapper.find('input').simulate('change', { destructor });
+
+      expect(destructor).toHaveBeenCalledTimes(1);
+    });
+
     it('updates the state accordingly if one of the handlers is removed', () => {
-      const bar = (state, increment) => state + increment;
+      const handler = (state, increment) => state + increment;
       const Passthrough = () => <div />;
       const WrappedComponent = props =>
         <div>
           {props.show
-            ? <div id={'bar'} onClick={props.update(bar, 2)} />
+            ? <div id={'bar'} onClick={props.update(handler, 2)} />
             : null}
 
-          <div id={'foo'} onClick={props.update(bar, 1)} />
+          <div id={'foo'} onClick={props.update(handler, 1)} />
 
           <Passthrough state={props.state} />
         </div>;


### PR DESCRIPTION
Since `setState()` is asynchronous, the synthetic event is already nullified when called inside `setState()`. To access the `event` in an asynchronous way we need to call `event.persist()` to remove the synthetic event from the pool and access references to the event. After the event is used we call `event.destructor()` which will nullify the event's properties after `setState()` is executed.